### PR TITLE
Add flake that exposes sigver scripts as apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+result
+*.bin
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # ci-yubi
+
 YubiHSM/Yubikey related code for CI/CD use
+
+## Usage with nix
+
+The `sigver` scripts are callable as nix apps:
+
+```sh
+nix run github:tiiuae/ci-yubi#sign -- --help
+
+nix run github:tiiuae/ci-yubi#verify -- --help
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1723991338,
+        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+{
+  description = "YubiHSM/Yubikey related code for CI/CD use";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      # deadnix: skip
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        pythonDependencies = with pkgs.python3Packages; [
+          azure-identity
+          azure-keyvault-certificates
+          azure-keyvault-keys
+        ];
+
+        sigver = pkgs.python3Packages.buildPythonPackage {
+          pname = "sigver";
+          version = "git";
+          format = "setuptools";
+          src = pkgs.lib.cleanSource ./py/sigver;
+          propagatedBuildInputs = pythonDependencies;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "ci-yubi";
+          packages = pythonDependencies;
+        };
+
+        packages = {
+          inherit sigver;
+        };
+
+        apps = {
+          sign = {
+            type = "app";
+            program = "${sigver}/bin/sign";
+          };
+
+          verify = {
+            type = "app";
+            program = "${sigver}/bin/verify";
+          };
+        };
+      }
+    );
+}

--- a/py/sigver/setup.py
+++ b/py/sigver/setup.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+# SPDX-License-Identifier: Apache-2.0
+
+from setuptools import setup
+
+setup(
+    name="sigver",
+    license="Apache-2.0",
+    python_requires=">=3.8",
+    install_requires=[
+        "azure-identity",
+        "azure-keyvault-certificates",
+        "azure-keyvault-keys",
+    ],
+    py_modules=["sha256tree", "sign", "verify"],
+    entry_points={
+        "console_scripts": [
+            "sign=sign:main",
+            "verify=verify:main",
+        ]
+    },
+)

--- a/py/sigver/sign.py
+++ b/py/sigver/sign.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
-import hashlib
 import sys
 
 from azure.identity import DefaultAzureCredential
@@ -14,6 +13,7 @@ from sha256tree import sha256sum
 KEY_VAULT_URL = "https://ghaf-devenv-ca.vault.azure.net/"
 CERTIFICATE_NAME = "."
 
+
 def show_help():
     print(f"Usage: {sys.argv[0]} [options] ")
     print()
@@ -25,21 +25,22 @@ def show_help():
     print("")
     sys.exit(0)
 
-def main(args: list[str]):
 
-    path="."
+def main():
+    args = sys.argv[:]
+    path = "."
     key_vault_url = KEY_VAULT_URL
     certificate_name = CERTIFICATE_NAME
     sigfile = "signature.bin"
 
     args.pop(0)
-    
+
     while args and args[0].startswith("--"):
         if args[0] == "--help":
             show_help()
         if args[0].startswith("--path="):
             args[0] = args[0].removeprefix("--path=")
-            path=args[0]
+            path = args[0]
         elif args[0].startswith("--cert="):
             args[0] = args[0].removeprefix("--cert=")
             certificate_name = args[0]
@@ -57,7 +58,9 @@ def main(args: list[str]):
 
     credential = DefaultAzureCredential()
 
-    certificate_client = CertificateClient(vault_url=key_vault_url, credential=credential)
+    certificate_client = CertificateClient(
+        vault_url=key_vault_url, credential=credential
+    )
     key_client = KeyClient(vault_url=key_vault_url, credential=credential)
 
     certificate = certificate_client.get_certificate(certificate_name)
@@ -68,13 +71,14 @@ def main(args: list[str]):
 
     crypto_client = CryptographyClient(key, credential)
 
-    digest = sha256sum(path, 1024*1024, True)
+    digest = sha256sum(path, 1024 * 1024, True)
 
     result = crypto_client.sign(SignatureAlgorithm.es256, digest)
 
-    print (result.signature)
+    print(result.signature)
     with open(sigfile, "wb") as file:
         file.write(result.signature)
 
+
 if __name__ == "__main__":
-    main(sys.argv[:])
+    main()

--- a/py/sigver/verify.py
+++ b/py/sigver/verify.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 # SPDX-License-Identifier: Apache-2.0
 
-import hashlib
 import sys
 
 from azure.identity import DefaultAzureCredential
@@ -14,6 +13,7 @@ from sha256tree import sha256sum
 KEY_VAULT_URL = "https://ghaf-devenv-ca.vault.azure.net/"
 CERTIFICATE_NAME = "."
 
+
 def show_help():
     print(f"Usage: {sys.argv[0]} [options] ")
     print()
@@ -25,21 +25,22 @@ def show_help():
     print("")
     sys.exit(0)
 
-def main(args: list[str]):
 
-    path="."
+def main():
+    args = sys.argv[:]
+    path = "."
     key_vault_url = KEY_VAULT_URL
     certificate_name = CERTIFICATE_NAME
     sigfile = "signature.bin"
 
     args.pop(0)
-    
+
     while args and args[0].startswith("--"):
         if args[0] == "--help":
             show_help()
         if args[0].startswith("--path="):
             args[0] = args[0].removeprefix("--path=")
-            path=args[0]
+            path = args[0]
         elif args[0].startswith("--cert="):
             args[0] = args[0].removeprefix("--cert=")
             certificate_name = args[0]
@@ -57,7 +58,9 @@ def main(args: list[str]):
 
     credential = DefaultAzureCredential()
 
-    certificate_client = CertificateClient(vault_url=key_vault_url, credential=credential)
+    certificate_client = CertificateClient(
+        vault_url=key_vault_url, credential=credential
+    )
     key_client = KeyClient(vault_url=key_vault_url, credential=credential)
 
     certificate = certificate_client.get_certificate(certificate_name)
@@ -68,14 +71,15 @@ def main(args: list[str]):
 
     crypto_client = CryptographyClient(key, credential)
 
-    digest = sha256sum(path, 1024*1024, True)
+    digest = sha256sum(path, 1024 * 1024, True)
 
     with open(sigfile, "rb") as file:
-        signature=file.read()
+        signature = file.read()
 
     result = crypto_client.verify(SignatureAlgorithm.es256, digest, signature)
-    print ("Verification result: ", result.is_valid)
+    print("Verification result: ", result.is_valid)
     assert result.is_valid
 
+
 if __name__ == "__main__":
-    main(sys.argv[:])
+    main()


### PR DESCRIPTION
Adds `flake.nix` that packages scripts in `py/sigver/` and exposes them as nix apps. A devshell is also included which installs the python dependencies in environment.

The scripts needed some modifications, and were also formatted with `black` (as is our standard for python). `setup.py` was also required for nix python builder to function properly.

Scripts can now be ran directly from github (in this example from my fork and branch):

```sh
nix run github:joinemm/ci-yubi/pr-add-flake#verify -- --help
```

Note that it's still required to have azure cli installed on your system, and run `az login` beforehand.