### PR TITLE
Secureboot Docker

### DIFF
--- a/nitrokey/Docker/Dockerfile
+++ b/nitrokey/Docker/Dockerfile
@@ -8,14 +8,24 @@ COPY openssl.cnf /etc/nitrokey/openssl.cnf
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     software-properties-common \
-    wget iputils-ping \
+    git wget iputils-ping pipx \
     pkgconf libssl-dev \
     opensc libengine-pkcs11-openssl
 
 RUN wget https://github.com/Nitrokey/nethsm-pkcs11/releases/download/v1.5.0/nethsm-pkcs11-vv1.5.0-x86_64-debian.12.so
 RUN cp nethsm-pkcs11-vv1.5.0-x86_64-debian.12.so /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so
 
+RUN DEBIAN_FRONTEND=noninteractive pipx install pynitrokey
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install sbsigntool
+
+RUN echo "export PATH=$PATH:/root/.local/bin" >> ~/.bashrc
+RUN echo "alias np='nitropy nethsm --no-verify-tls --host ppclabz.net:8443'" >> ~/.bashrc
 RUN echo "alias p='pkcs11-tool --module /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so --login --login-type so --so-pin Administrator'" >> ~/.bashrc
 RUN echo "alias pd='RUST_LOG=debug pkcs11-tool --module /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so --login --login-type so --so-pin Administrator'" >> ~/.bashrc
 RUN echo "export P11NETHSM_CONFIG_FILE=/etc/nitrokey/p11nethsm.conf" >> ~/.bashrc
 RUN echo "export OPENSSL_CONF=/etc/nitrokey/openssl.cnf" >> ~/.bashrc
+
+# Extras:
+
+RUN git clone https://github.com/tiiuae/scs-pki-research.git

--- a/nitrokey/Docker/Dockerfile-1.1.1
+++ b/nitrokey/Docker/Dockerfile-1.1.1
@@ -1,0 +1,51 @@
+FROM ubuntu:20.04
+
+WORKDIR /app
+RUN mkdir /etc/nitrokey
+COPY p11nethsm.conf /etc/nitrokey/p11nethsm.conf
+COPY openssl.cnf /etc/nitrokey/openssl.cnf
+COPY vmlinuz-6.8.0-52-generic /app
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
+    echo "Etc/UTC" > /etc/timezone && \
+    apt-get update && \
+    apt-get install -y tzdata python3.8-venv curl
+
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    git wget iputils-ping pipx vim gdb \
+    pkgconf libssl-dev gnutls-bin \
+    opensc libengine-pkcs11-openssl \
+    build-essential
+
+#RUN wget https://github.com/Nitrokey/nethsm-pkcs11/releases/download/v1.5.0/nethsm-pkcs11-vv1.5.0-x86_64-debian.12.so
+#RUN cp nethsm-pkcs11-vv1.5.0-x86_64-debian.12.so /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so
+
+# We need to rebuild the libnethsm_pkcs11.so to run on this Docker
+# So, install Rust toolchain, clone the source and build
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN mkdir /app/addons
+RUN cd /app/addons; git clone https://github.com/Nitrokey/nethsm-pkcs11.git
+RUN . $HOME/.cargo/env; cd /app/addons/nethsm-pkcs11; cargo build --release
+RUN cp /app/addons/nethsm-pkcs11/target/release/libnethsm_pkcs11.so /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so
+
+# Install nitropy
+RUN DEBIAN_FRONTEND=noninteractive pipx install pynitrokey
+
+# Install sbsigntool
+RUN DEBIAN_FRONTEND=noninteractive apt-get install sbsigntool
+
+# Add Aliases and ENV vars
+RUN echo "export PATH=$PATH:/root/.local/bin" >> ~/.bashrc
+RUN echo "alias np='nitropy nethsm --no-verify-tls --host ppclabz.net:8443'" >> ~/.bashrc
+RUN echo "alias p='pkcs11-tool --module /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so --login --login-type so --so-pin Administrator'" >> ~/.bashrc
+RUN echo "alias pd='RUST_LOG=debug pkcs11-tool --module /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so --login --login-type so --so-pin Administrator'" >> ~/.bashrc
+RUN echo "alias openssl='OPENSSL_CONF=/etc/nitrokey/openssl.cnf openssl'" >> ~/.bashrc
+RUN echo "export P11NETHSM_CONFIG_FILE=/etc/nitrokey/p11nethsm.conf" >> ~/.bashrc
+RUN echo "export OPENSSL_CONF=/etc/nitrokey/openssl.cnf" >> ~/.bashrc
+
+# Extras:
+
+RUN git clone https://github.com/tiiuae/scs-pki-research.git

--- a/nitrokey/Docker/Dockerfile-1.1.1
+++ b/nitrokey/Docker/Dockerfile-1.1.1
@@ -4,7 +4,6 @@ WORKDIR /app
 RUN mkdir /etc/nitrokey
 COPY p11nethsm.conf /etc/nitrokey/p11nethsm.conf
 COPY openssl.cnf /etc/nitrokey/openssl.cnf
-COPY vmlinuz-6.8.0-52-generic /app
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
@@ -19,8 +18,6 @@ RUN apt-get update && apt-get install -y \
     opensc libengine-pkcs11-openssl \
     build-essential
 
-#RUN wget https://github.com/Nitrokey/nethsm-pkcs11/releases/download/v1.5.0/nethsm-pkcs11-vv1.5.0-x86_64-debian.12.so
-#RUN cp nethsm-pkcs11-vv1.5.0-x86_64-debian.12.so /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so
 
 # We need to rebuild the libnethsm_pkcs11.so to run on this Docker
 # So, install Rust toolchain, clone the source and build

--- a/nitrokey/Docker/openssl-1.1.1.cnf
+++ b/nitrokey/Docker/openssl-1.1.1.cnf
@@ -1,0 +1,14 @@
+openssl_conf = openssl_init
+
+[openssl_init]
+engines = engine_section
+
+[engine_section]
+pkcs11 = pkcs11_section
+
+[pkcs11_section]
+engine_id = pkcs11
+#dynamic_path = /usr/lib/x86_64-linux-gnu/engines-3/libpkcs11.so
+dynamic_path = /usr/lib/x86_64-linux-gnu/engines-1.1/libpkcs11.so
+MODULE_PATH = /usr/lib/x86_64-linux-gnu/pkcs11/libnethsm_pkcs11.so
+init = 0


### PR DESCRIPTION
Added Docker container with SecureBoot tooling. 

Downgraded openSSL to 1.1.1 (required by SBSIGN)
Added netHSM pkcs11 module rebuild

Nitropy still requires some work (doesn't want to cooperate with older Linux apparently)