### PR TITLE
Fix parallel uefisign

### DIFF
--- a/secboot/signme_offline.sh
+++ b/secboot/signme_offline.sh
@@ -21,13 +21,13 @@ fi
 CERT="$1"
 PKEY="$2"
 DISK_IMAGE_ZST="$3"
-SUBDIR="$4"
+OUTDIR="$4"
 
 TMPWDIR="$(mktemp -d --suffix .uefisign)"
 DISK_IMAGE="$TMPWDIR/disk.raw"
 EFI_IMAGE="$TMPWDIR/efi-partition.img"
 SIGNED_EFI="$TMPWDIR/BOOTX64.EFI.signed"
-SIGNED_ZST="$SUBDIR/signed_ghaf_0.0.1.raw.zst"
+SIGNED_ZST="$OUTDIR/signed_ghaf_0.0.1.raw.zst"
 
 on_exit() {
   log "[DEBUG] Cleanup (TMPWDIR:$TMPWDIR)"
@@ -170,7 +170,7 @@ dd if="$EFI_IMAGE" of="$DISK_IMAGE" bs=512 seek="$EFI_START" conv=notrunc status
 
 log "[+] Signed image updated in $DISK_IMAGE"
 
-mkdir -p "$SUBDIR"
+mkdir -p "$OUTDIR"
 if [[ "$input_type" == "zst" ]]; then
   log "[*] Recompressing signed image to $SIGNED_ZST..."
   zstd -f "$DISK_IMAGE" -o "$SIGNED_ZST"


### PR DESCRIPTION
Misc fixes to `secboot/signme_offline.sh`:
- Drop support for `.iso` images, which were not properly supported by the `uefisign` flake app.
- Use temporary directory (created with `mktemp -d`) for temporary files instead of current working directory. This fixes an issue with parallel `uefisign` execution: before this change, parallel `uefisign` processes might overwrite or remove each other's temporary files when they were invoked from the same working directory.
- Make the function `err_report` also output the actual failing command. This is needed since the line numbers - as reported by `$LINENO` - do not exactly match the script version in scm when the script is called via the `uefisign` flake app due to the wrapping that `pkgs.writeShellApplication` adds.
- Rename variable `SUBDIR` to `OUTDIR` which better matches the purpose.

Tested that the `uefisign` flake app produces what looks like a valid signed image, given correct arguments. However, I have **not** tested that the produced image boots properly.