### PR TITLE
Feature/ephemeral certs cont

### DIFF
--- a/ephemeral-certs/ca/create-test-ca.sh
+++ b/ephemeral-certs/ca/create-test-ca.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Config (adjust as needed) ---
+: "${P11MODULE:?Set P11MODULE to the netHSM PKCS#11 module path, e.g. /nix/store/.../libnethsm_pkcs11.so}"
+TOKEN_LABEL="${TOKEN_LABEL:-NetHSM}"
+
+ROOT_LABEL="${ROOT_LABEL:-ghaf-root-ca}"
+INT_LABEL="${INT_LABEL:-ghaf-intermediate-ca}"
+
+ROOT_SUBJ="${ROOT_SUBJ:-/C=FI/O=Ghaf/CN=Ghaf Root CA}"
+INT_SUBJ="${INT_SUBJ:-/C=FI/O=Ghaf/CN=Ghaf Intermediate CA}"
+
+ROOT_DAYS="${ROOT_DAYS:-7300}"   # 20 years
+INT_DAYS="${INT_DAYS:-3650}"     # 10 years
+
+ROOT_EXT="${ROOT_EXT:-root.ext}"
+INT_EXT="${INT_EXT:-intermediate.ext}"
+
+OUTDIR="${OUTDIR:-pki-out}"
+mkdir -p "$OUTDIR"
+
+ROOT_CSR="$OUTDIR/root-ca.csr"
+ROOT_CERT="$OUTDIR/root-ca.pem"
+
+INT_CSR="$OUTDIR/intermediate-ca.csr"
+INT_CERT="$OUTDIR/intermediate-ca.pem"
+
+# --- Helper: PKCS#11 URIs ---
+ROOT_KEY_URI="pkcs11:token=${TOKEN_LABEL};object=${ROOT_LABEL};type=private"
+INT_KEY_URI="pkcs11:token=${TOKEN_LABEL};object=${INT_LABEL};type=private"
+
+# --- 0) Sanity: show token slots (optional) ---
+echo "[*] PKCS#11 module: $P11MODULE"
+pkcs11-tool --module "$P11MODULE" -L >/dev/null
+
+# --- 1) Root CA keypair in netHSM ---
+echo "[*] Creating Root CA keypair in netHSM (label: $ROOT_LABEL)"
+pkcs11-tool --module "$P11MODULE" \
+  --keypairgen --key-type EC:prime256v1 \
+  --label "$ROOT_LABEL"
+
+# --- 2) Root CA CSR (key stays in netHSM) ---
+echo "[*] Creating Root CA CSR -> $ROOT_CSR"
+openssl req -new \
+  -provider pkcs11 -provider default \
+  -key "$ROOT_KEY_URI" \
+  -subj "$ROOT_SUBJ" \
+  -out "$ROOT_CSR"
+
+# --- 3) Root CA self-signed certificate (signed by netHSM key) ---
+echo "[*] Self-signing Root CA certificate -> $ROOT_CERT"
+openssl x509 -req \
+  -in "$ROOT_CSR" \
+  -provider pkcs11 -provider default \
+  -signkey "$ROOT_KEY_URI" \
+  -days "$ROOT_DAYS" -sha256 \
+  -extfile "$ROOT_EXT" \
+  -out "$ROOT_CERT"
+
+# --- 4) Intermediate CA keypair in netHSM ---
+echo "[*] Creating Intermediate CA keypair in netHSM (label: $INT_LABEL)"
+pkcs11-tool --module "$P11MODULE" \
+  --keypairgen --key-type EC:prime256v1 \
+  --label "$INT_LABEL"
+
+# --- 5) Intermediate CA CSR (key stays in netHSM) ---
+echo "[*] Creating Intermediate CA CSR -> $INT_CSR"
+openssl req -new \
+  -provider pkcs11 -provider default \
+  -key "$INT_KEY_URI" \
+  -subj "$INT_SUBJ" \
+  -out "$INT_CSR"
+
+# --- 6) Intermediate CA certificate signed by Root CA (root key in netHSM) ---
+echo "[*] Signing Intermediate CA certificate with Root CA -> $INT_CERT"
+openssl x509 -req \
+  -in "$INT_CSR" \
+  -provider pkcs11 -provider default \
+  -CA "$ROOT_CERT" \
+  -CAkey "$ROOT_KEY_URI" \
+  -CAcreateserial \
+  -days "$INT_DAYS" -sha256 \
+  -extfile "$INT_EXT" \
+  -out "$INT_CERT"
+
+echo
+echo "[+] Done."
+echo "    Root CA cert:         $ROOT_CERT"
+echo "    Intermediate CA cert: $INT_CERT"
+echo "    Root CSR:             $ROOT_CSR"
+echo "    Intermediate CSR:     $INT_CSR"
+echo "    Serial file:          $OUTDIR/*.srl (created by -CAcreateserial)"

--- a/ephemeral-certs/intermediate.ext
+++ b/ephemeral-certs/intermediate.ext
@@ -1,0 +1,4 @@
+basicConstraints = critical, CA:TRUE, pathlen:0
+keyUsage = critical, keyCertSign, cRLSign
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer

--- a/ephemeral-certs/leaf.ext
+++ b/ephemeral-certs/leaf.ext
@@ -1,0 +1,5 @@
+basicConstraints = critical, CA:FALSE
+keyUsage = critical, digitalSignature
+extendedKeyUsage = codeSigning
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer

--- a/ephemeral-certs/root.ext
+++ b/ephemeral-certs/root.ext
@@ -1,0 +1,2 @@
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign

--- a/ephemeral-certs/sign-artifact.sh
+++ b/ephemeral-certs/sign-artifact.sh
@@ -38,8 +38,8 @@ END=$(date -u -d "+10 minutes" +"%Y%m%d%H%M%SZ")
 
 openssl x509 -req \
 	-in "$CSR_FILE" \
-	-CA testRoot.pem \
-	-CAkey "pkcs11:token=NetHSM;object=testRoot;type=private" \
+	-CA ca/pki-out/intermediate-ca.pem \
+	-CAkey "pkcs11:token=NetHSM;object=ghaf-intermediate-ca;type=private" \
 	-CAcreateserial \
 	-out "$CRT_FILE" \
 	-not_before "$START" \
@@ -74,7 +74,6 @@ openssl ts -query \
 curl -H "Content-Type: application/timestamp-query" \
 	--data-binary @"$DATA.sig.tsq" \
 	--fail --show-error --max-time 15 \
-	--cacert "$TSA_CA" \
 	"$TSA_URL" >"$DATA.sig.tsr"
 
 # Delete keypair

--- a/ephemeral-certs/sign-artifact.sh
+++ b/ephemeral-certs/sign-artifact.sh
@@ -2,12 +2,25 @@
 # SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# This script is expecting $P11MODULE to be set
+set -euo pipefail
 
 DATA="${1:?usage: $0 <artifact>}"
+: "${P11MODULE:?P11MODULE must point to the PKCS#11 module}"
 
 LABEL="ghaf-test-leaf" # Leaf certificate label
-#DATA="p11nethsm.conf"  # Data to be signed / timestamped
+TSA_URL="${TSA_URL:-https://freetsa.org/tsr}"
+: "${TSA_CA:?TSA_CA must point to the TSA certificate/CA bundle}"
+LEAF_CERT_OUT="${LEAF_CERT_OUT:-${LABEL}.pem}"
+
+CSR_FILE="$(mktemp "${LABEL}.csr.XXXX")"
+CRT_FILE="$(mktemp "${LABEL}.pem.XXXX")"
+
+cleanup() {
+	pkcs11-tool --module "$P11MODULE" --delete-object --type privkey --label "$LABEL" >/dev/null 2>&1 || true
+	pkcs11-tool --module "$P11MODULE" --delete-object --type pubkey --label "$LABEL" >/dev/null 2>&1 || true
+	rm -f "$CSR_FILE" "$CRT_FILE" "${LABEL}.srl"
+}
+trap cleanup EXIT
 
 # Create keypair
 pkcs11-tool --module "$P11MODULE" --keypairgen --key-type EC:prime256v1 --label "$LABEL"
@@ -16,24 +29,27 @@ pkcs11-tool --module "$P11MODULE" --keypairgen --key-type EC:prime256v1 --label 
 openssl req -new \
 	-provider pkcs11 -provider default \
 	-key "pkcs11:token=NetHSM;object=$LABEL" \
-	-out "$LABEL.csr" \
+	-out "$CSR_FILE" \
 	-subj "/C=FI/ST=Tampere/L=Tampere/O=Ghaf/CN=Ghaf Infra Sign ED25519"
 
-# Sign CSR
-START=$(date -u +"%Y%m%d%H%M%SZ")
-END=$(date -u -d "+1 minute" +"%Y%m%d%H%M%SZ")
+# Sign CSR with a short-lived certificate (allow small clock skew)
+START=$(date -u -d "-1 minute" +"%Y%m%d%H%M%SZ")
+END=$(date -u -d "+10 minutes" +"%Y%m%d%H%M%SZ")
 
 openssl x509 -req \
-	-in "$LABEL.csr" \
+	-in "$CSR_FILE" \
 	-CA testRoot.pem \
 	-CAkey "pkcs11:token=NetHSM;object=testRoot;type=private" \
 	-CAcreateserial \
-	-out "$LABEL.pem" \
+	-out "$CRT_FILE" \
 	-not_before "$START" \
 	-not_after "$END" \
 	-sha256 \
 	-provider pkcs11 \
 	-provider default
+
+# Persist leaf certificate to a predictable location for downstream verification
+cp "$CRT_FILE" "$LEAF_CERT_OUT"
 
 # List objects
 echo "---------------------------------------------------------------------"
@@ -48,15 +64,18 @@ openssl pkeyutl -sign -rawin \
 	-in "$DATA" \
 	-out "$DATA.sig"
 
-# Timestamp signature
+# Timestamp signature (nonce, pinned TSA CA, timeout, and curl failure on HTTP errors)
 openssl ts -query \
 	-data "$DATA.sig" \
-	-no_nonce \
 	-sha512 \
 	-cert \
 	-out "$DATA.sig.tsq"
 
-curl -H "Content-Type: application/timestamp-query" --data-binary @"$DATA.sig.tsq" https://freetsa.org/tsr >"$DATA.sig.tsr"
+curl -H "Content-Type: application/timestamp-query" \
+	--data-binary @"$DATA.sig.tsq" \
+	--fail --show-error --max-time 15 \
+	--cacert "$TSA_CA" \
+	"$TSA_URL" >"$DATA.sig.tsr"
 
 # Delete keypair
 pkcs11-tool --module "$P11MODULE" \

--- a/ephemeral-certs/verify_artifact.sh
+++ b/ephemeral-certs/verify_artifact.sh
@@ -38,9 +38,12 @@ openssl x509 -in "$LEAF" -noout -text | grep -q "Extended Key Usage" && \
 
 echo "Step 1 - Verify artifact signature using leaf's pubkey"
 # 1) Verify artifact signature using leaf public key
-openssl x509 -in "$LEAF" -pubkey -noout > leaf.pub.pem
+LEAF_PUB_PEM="$(mktemp -t leaf.pub.pem.XXXXXX)"
+trap 'rm -f "$LEAF_PUB_PEM"' EXIT
 
-openssl dgst -sha256 -verify leaf.pub.pem -signature "$SIG" "$ARTIFACT"
+openssl x509 -in "$LEAF" -pubkey -noout > "$LEAF_PUB_PEM"
+
+openssl dgst -sha256 -verify "$LEAF_PUB_PEM" -signature "$SIG" "$ARTIFACT"
 
 echo "Step 2 - Verify TSR"
 # 2) Verify TSR cryptographically (timestamp token signs the SIG)


### PR DESCRIPTION
Summary

This PR strengthens ephemeral certificate handling by enforcing stricter validation rules and, as a side effect, introducing a script to create a test CA on netHSM.

Changes

 - Add a script to create a test CA on netHSM
 - Introduce certificate extension files with enforced constraints
 - Implement full trust chain verification
 - Enforce Extended Key Usage (EKU) checks