### PR TITLE
Stream UEFI raw image signing through zstd

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,8 @@
           azure-keyvault-keys
         ];
 
+        uefiRawImageLib = builtins.readFile ./secboot/uefi-raw-image-lib.sh;
+
         sigver = pkgs.python3Packages.buildPythonPackage {
           pname = "sigver";
           version = "git";
@@ -81,7 +83,7 @@
             ++ [
               systemd-sbsign
             ];
-          text = builtins.readFile ./secboot/uefi-sign-simple.sh;
+          text = uefiRawImageLib + "\n" + builtins.readFile ./secboot/uefi-sign-simple.sh;
         };
 
         uefisignraw = pkgs.writeShellApplication {
@@ -99,7 +101,7 @@
             ++ [
               systemd-sbsign
             ];
-          text = builtins.readFile ./secboot/uefi-sign-raw.sh;
+          text = uefiRawImageLib + "\n" + builtins.readFile ./secboot/uefi-sign-raw.sh;
         };
 
         uefisigniso = pkgs.writeShellApplication {
@@ -156,11 +158,15 @@
           name = "uefisign-azure";
           runtimeInputs =
             (with pkgs; [
+              coreutils
+              curl
+              jq
               util-linux # for fdisk, losetup, etc.
               mtools
               gawk
               xorriso
               systemdUkify
+              zstd
             ])
             ++ [
               tii-sbsign
@@ -188,7 +194,9 @@
           };
 
           text = ''
-            exec ${./secboot/uefi-sign-azure.sh} ${./secboot/uefi-signing-cert.pem} "$@"
+            export UEFISIGN_AZURE_CERT=${./secboot/uefi-signing-cert.pem}
+            ${uefiRawImageLib}
+            ${builtins.readFile ./secboot/uefi-sign-azure.sh}
           '';
         };
       in

--- a/secboot/uefi-deployed-mode/Dockerfile
+++ b/secboot/uefi-deployed-mode/Dockerfile
@@ -150,12 +150,13 @@ RUN chmod +x /usr/local/bin/init-softhsm.sh
 # Make token storage a volume so keys survive container restarts
 VOLUME ["/var/lib/softhsm/tokens", "/opt/keys"]
 
-COPY ghaf_sign_iso.sh /root/
-COPY signme_offline.sh /root/
+COPY uefi-deployed-mode/ghaf_sign_iso.sh /root/
+COPY uefi-deployed-mode/signme_offline.sh /root/
+COPY uefi-raw-image-lib.sh /
 
-COPY provision-uefi-auth.sh /root/
-COPY openssl-engine.cnf /root/
-COPY demo.sh /root
+COPY uefi-deployed-mode/provision-uefi-auth.sh /root/
+COPY uefi-deployed-mode/openssl-engine.cnf /root/
+COPY uefi-deployed-mode/demo.sh /root
 ENV OPENSSL_CONF=/root/openssl-engine.cnf
 RUN chmod +x /root/provision-uefi-auth.sh
 RUN chmod +x /root/demo.sh

--- a/secboot/uefi-deployed-mode/Instructions.md
+++ b/secboot/uefi-deployed-mode/Instructions.md
@@ -3,7 +3,12 @@
 ## Build SoftHSM Docker image
 
 ```
-docker build --network=host --build-arg TOKEN_LABEL=UEFI-Token --build-arg SO_PIN=3537363231383830 --build-arg USER_PIN=123456 -t softhsm-secboot:latest .
+docker build --network=host \
+  -f uefi-deployed-mode/Dockerfile \
+  --build-arg TOKEN_LABEL=UEFI-Token \
+  --build-arg SO_PIN=3537363231383830 \
+  --build-arg USER_PIN=123456 \
+  -t softhsm-secboot:latest .
 [+] Building 19.4s (12/12) FINISHED                                                       docker:default
  => [internal] load build definition from Dockerfile                                                0.0s
  => => transferring dockerfile: 5.24kB                                                              0.0s

--- a/secboot/uefi-deployed-mode/README.md
+++ b/secboot/uefi-deployed-mode/README.md
@@ -8,7 +8,7 @@ git checkout feature/uefi-deployed
 
 git pull origin feature/uefi-deployed
 
-cd secboot/uefi-deployed-mode
+cd secboot
 
 
 ### Prepare the Shared Folder
@@ -20,9 +20,11 @@ cp /path/to/your.iso out/
 
 ### Build the Docker image
 
-from uefi-deployed-mode folder, build the Docker image
+from the secboot folder, build the Docker image
 
-docker build --network=host  -t softhsm-secboot:latest .
+docker build --network=host \
+  -f uefi-deployed-mode/Dockerfile \
+  -t softhsm-secboot:latest .
 
 ### Run the Docker Container
 

--- a/secboot/uefi-deployed-mode/signme_offline.sh
+++ b/secboot/uefi-deployed-mode/signme_offline.sh
@@ -13,6 +13,13 @@ err_report() {
 }
 trap 'err_report $LINENO' ERR
 
+if ! declare -F uefisign_find_efi_partition >/dev/null; then
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck disable=SC1091
+  # shellcheck source=../uefi-raw-image-lib.sh
+  source "$SCRIPT_DIR/../uefi-raw-image-lib.sh"
+fi
+
 if [[ $# -ne 4 ]]; then
   log "[!] Usage: $0 <certificate> <private-key> <disk-image.zst> <out-dir>"
   exit 1
@@ -24,7 +31,6 @@ DISK_IMAGE_ZST="$3"
 OUTDIR="$4"
 
 TMPWDIR="$(mktemp -d --suffix .uefisign)"
-DISK_IMAGE="$TMPWDIR/disk.raw"
 EFI_IMAGE="$TMPWDIR/efi-partition.img"
 SIGNED_EFI="$TMPWDIR/BOOTX64.EFI.signed"
 SIGNED_ZST="$OUTDIR/signed_ghaf_0.0.1.raw.zst"
@@ -50,25 +56,14 @@ case "$DISK_IMAGE_ZST" in
     ;;
 esac
 
-if [[ "$input_type" == "zst" ]]; then
-  log "[*] Decompressing image: $DISK_IMAGE_ZST -> $DISK_IMAGE"
-  zstd -d "$DISK_IMAGE_ZST" -o "$DISK_IMAGE"
-fi
-log "[*] Disk image: $DISK_IMAGE"
-chmod 666 "$DISK_IMAGE" || true
-
 log "[*] Locating EFI partition offset and size..."
-read -r EFI_START SECTORS < <(fdisk -l "$DISK_IMAGE" | awk '$0 ~ /EFI / { print $2, $4 }')
-if [[ -z "${EFI_START:-}" || -z "${SECTORS:-}" ]]; then
-  log "[!] Could not determine EFI partition info from image"
-  exit 1
-fi
+read -r EFI_START SECTORS < <(uefisign_find_efi_partition "$DISK_IMAGE_ZST" "$input_type" "$TMPWDIR/partition-prefix.img")
 EFI_OFFSET=$((EFI_START * 512))
 EFI_SIZE=$((SECTORS * 512))
 log "[*] EFI offset: $EFI_OFFSET, size: $EFI_SIZE bytes"
 
 log "[*] Extracting EFI partition to $EFI_IMAGE..."
-dd if="$DISK_IMAGE" of="$EFI_IMAGE" bs=512 skip="$EFI_START" count="$SECTORS" status=none
+uefisign_extract_raw_range_to_file "$DISK_IMAGE_ZST" "$input_type" "$EFI_OFFSET" "$EFI_SIZE" "$EFI_IMAGE"
 
 fat_path() {
   # Convert backslashes to forward slashes, ensure leading slash
@@ -170,15 +165,8 @@ mcopy -o -i "$EFI_IMAGE" "$TMPWDIR/tmp_entry" "::/loader/entries/$(basename "$en
 log "[*] Updating fallback EFI/BOOT/BOOTX64.EFI ..."
 mcopy -o -i "$EFI_IMAGE" "$SIGNED_EFI" ::/EFI/BOOT/BOOTX64.EFI
 
-log "[*] Writing updated EFI partition back to disk image..."
-dd if="$EFI_IMAGE" of="$DISK_IMAGE" bs=512 seek="$EFI_START" conv=notrunc status=none
-
-log "[+] Signed image updated in $DISK_IMAGE"
-
 mkdir -p "$OUTDIR"
-if [[ "$input_type" == "zst" ]]; then
-  log "[*] Recompressing signed image to $SIGNED_ZST..."
-  zstd -f "$DISK_IMAGE" -o "$SIGNED_ZST"
-fi
+log "[*] Streaming signed image to $SIGNED_ZST..."
+uefisign_write_signed_raw_image "$DISK_IMAGE_ZST" "$input_type" "$EFI_IMAGE" "$EFI_OFFSET" "$EFI_SIZE" "$SIGNED_ZST" zst
 
 log "[+] EFI Signing Success!"

--- a/secboot/uefi-raw-image-lib.sh
+++ b/secboot/uefi-raw-image-lib.sh
@@ -1,0 +1,335 @@
+# SPDX-FileCopyrightText: 2022-2024 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+# shellcheck shell=bash
+
+# Helpers for updating an EFI System Partition inside a raw disk image without
+# materializing the full raw image on disk.
+
+UEFISIGN_SECTOR_SIZE="${UEFISIGN_SECTOR_SIZE:-512}"
+UEFISIGN_STREAM_BS="${UEFISIGN_STREAM_BS:-4M}"
+UEFISIGN_PARTITION_PREFIX_BYTES="${UEFISIGN_PARTITION_PREFIX_BYTES:-1048576}"
+UEFISIGN_MAX_PARTITION_PREFIX_BYTES="${UEFISIGN_MAX_PARTITION_PREFIX_BYTES:-67108864}"
+
+uefisign_log() {
+  if declare -F log >/dev/null; then
+    log "$@"
+  else
+    echo "$*"
+  fi
+}
+
+uefisign_die() {
+  uefisign_log "[!] $*" >&2
+  exit 1
+}
+
+uefisign_raw_input() {
+  local input="$1"
+  local input_type="$2"
+
+  case "$input_type" in
+  zst)
+    zstd -dc -- "$input"
+    ;;
+  raw)
+    cat -- "$input"
+    ;;
+  *)
+    uefisign_die "Unsupported raw input type: $input_type"
+    ;;
+  esac
+}
+
+uefisign_extract_raw_range_to_file() {
+  local input="$1"
+  local input_type="$2"
+  local skip_bytes="$3"
+  local count_bytes="$4"
+  local output="$5"
+  local statuses input_rc dd_rc actual_size
+
+  if ((count_bytes < 0)); then
+    uefisign_die "Invalid byte count: $count_bytes"
+  fi
+
+  rm -f -- "$output"
+  if ((count_bytes == 0)); then
+    : >"$output"
+    return 0
+  fi
+
+  set +e
+  set +o pipefail
+  # zstd streams are not seekable here, so byte ranges are selected by
+  # re-reading from the start and letting dd skip/count the raw bytes.
+  uefisign_raw_input "$input" "$input_type" |
+    dd of="$output" bs="$UEFISIGN_STREAM_BS" iflag=fullblock,skip_bytes,count_bytes skip="$skip_bytes" count="$count_bytes" status=none
+  statuses=("${PIPESTATUS[@]}")
+  set -o pipefail
+  set -e
+
+  input_rc="${statuses[0]}"
+  dd_rc="${statuses[1]}"
+  if ((dd_rc != 0)); then
+    uefisign_die "Failed to extract byte range from raw image"
+  fi
+  # For bounded reads dd exits after count_bytes and may close the pipe before
+  # zstd/cat finish writing. SIGPIPE is expected in that case.
+  if ((input_rc != 0 && input_rc != 141)); then
+    uefisign_die "Failed to read raw image stream"
+  fi
+
+  actual_size="$(stat -c%s -- "$output")"
+  if ((actual_size != count_bytes)); then
+    uefisign_die "Short read from raw image: expected $count_bytes bytes, got $actual_size"
+  fi
+}
+
+uefisign_stream_raw_range() {
+  local input="$1"
+  local input_type="$2"
+  local skip_bytes="$3"
+  local count_bytes="${4:-}"
+  local iflags statuses input_rc dd_rc
+
+  if [[ -n "$count_bytes" && "$count_bytes" -eq 0 ]]; then
+    return 0
+  fi
+
+  iflags="fullblock,skip_bytes"
+  if [[ -n "$count_bytes" ]]; then
+    iflags+=",count_bytes"
+  fi
+
+  set +e
+  set +o pipefail
+  if [[ -n "$count_bytes" ]]; then
+    uefisign_raw_input "$input" "$input_type" |
+      dd bs="$UEFISIGN_STREAM_BS" iflag="$iflags" skip="$skip_bytes" count="$count_bytes" status=none
+  else
+    uefisign_raw_input "$input" "$input_type" |
+      dd bs="$UEFISIGN_STREAM_BS" iflag="$iflags" skip="$skip_bytes" status=none
+  fi
+  statuses=("${PIPESTATUS[@]}")
+  set -o pipefail
+  set -e
+
+  input_rc="${statuses[0]}"
+  dd_rc="${statuses[1]}"
+  if ((dd_rc != 0)); then
+    return "$dd_rc"
+  fi
+  if [[ -n "$count_bytes" ]]; then
+    if ((input_rc != 0 && input_rc != 141)); then
+      return "$input_rc"
+    fi
+  elif ((input_rc != 0)); then
+    return "$input_rc"
+  fi
+}
+
+uefisign_hex_at() {
+  local file="$1"
+  local offset="$2"
+  local length="$3"
+
+  od -An -v -j "$offset" -N "$length" -t x1 -- "$file" | tr -d ' \n'
+}
+
+uefisign_le_uint_at() {
+  local file="$1"
+  local offset="$2"
+  local length="$3"
+  local hex reversed
+  local i
+
+  hex="$(uefisign_hex_at "$file" "$offset" "$length")"
+  if ((${#hex} != length * 2)); then
+    uefisign_die "Could not read $length bytes at offset $offset"
+  fi
+
+  reversed=""
+  for ((i = ${#hex} - 2; i >= 0; i -= 2)); do
+    reversed+="${hex:i:2}"
+  done
+
+  printf '%s\n' "$((16#$reversed))"
+}
+
+uefisign_parse_mbr_esp() {
+  local prefix="$1"
+  local entry type start sectors
+  local index pass
+
+  # Prefer the official EFI MBR type, then fall back to FAT32 types used by
+  # some legacy aarch64 images for their ESP.
+  for pass in official fat32; do
+    for index in 0 1 2 3; do
+      entry=$((446 + index * 16))
+      type="$(uefisign_hex_at "$prefix" $((entry + 4)) 1)"
+      if [[ "$pass" == "official" && "$type" != "ef" ]]; then
+        continue
+      fi
+      if [[ "$pass" == "fat32" && "$type" != "0b" && "$type" != "0c" ]]; then
+        continue
+      fi
+      start="$(uefisign_le_uint_at "$prefix" $((entry + 8)) 4)"
+      sectors="$(uefisign_le_uint_at "$prefix" $((entry + 12)) 4)"
+      if ((start > 0 && sectors > 0)); then
+        printf '%s %s\n' "$start" "$sectors"
+        return 0
+      fi
+    done
+  done
+
+  return 1
+}
+
+uefisign_gpt_entries_end() {
+  local prefix="$1"
+  local entries_lba entry_count entry_size entries_offset entries_end
+
+  entries_lba="$(uefisign_le_uint_at "$prefix" $((UEFISIGN_SECTOR_SIZE + 72)) 8)"
+  entry_count="$(uefisign_le_uint_at "$prefix" $((UEFISIGN_SECTOR_SIZE + 80)) 4)"
+  entry_size="$(uefisign_le_uint_at "$prefix" $((UEFISIGN_SECTOR_SIZE + 84)) 4)"
+
+  if ((entries_lba < 2)); then
+    uefisign_die "Invalid GPT partition entry LBA: $entries_lba"
+  fi
+  if ((entry_count < 1 || entry_count > 32768)); then
+    uefisign_die "Invalid GPT partition entry count: $entry_count"
+  fi
+  if ((entry_size < 128 || entry_size > 4096)); then
+    uefisign_die "Invalid GPT partition entry size: $entry_size"
+  fi
+
+  entries_offset=$((entries_lba * UEFISIGN_SECTOR_SIZE))
+  entries_end=$((entries_offset + entry_count * entry_size))
+  if ((entries_end > UEFISIGN_MAX_PARTITION_PREFIX_BYTES)); then
+    uefisign_die "GPT partition table is unexpectedly large: $entries_end bytes"
+  fi
+
+  printf '%s\n' "$entries_end"
+}
+
+uefisign_parse_gpt_esp() {
+  local prefix="$1"
+  # GPT GUID fields are stored in mixed endian order. This is the on-disk byte
+  # sequence for C12A7328-F81F-11D2-BA4B-00A0C93EC93B.
+  local esp_guid="28732ac11ff8d211ba4b00a0c93ec93b"
+  local entries_lba entry_count entry_size entries_offset entry_offset
+  local type_guid first_lba last_lba sectors
+  local index
+
+  entries_lba="$(uefisign_le_uint_at "$prefix" $((UEFISIGN_SECTOR_SIZE + 72)) 8)"
+  entry_count="$(uefisign_le_uint_at "$prefix" $((UEFISIGN_SECTOR_SIZE + 80)) 4)"
+  entry_size="$(uefisign_le_uint_at "$prefix" $((UEFISIGN_SECTOR_SIZE + 84)) 4)"
+  entries_offset=$((entries_lba * UEFISIGN_SECTOR_SIZE))
+
+  for ((index = 0; index < entry_count; index++)); do
+    entry_offset=$((entries_offset + index * entry_size))
+    type_guid="$(uefisign_hex_at "$prefix" "$entry_offset" 16)"
+    if [[ "$type_guid" == "$esp_guid" ]]; then
+      first_lba="$(uefisign_le_uint_at "$prefix" $((entry_offset + 32)) 8)"
+      last_lba="$(uefisign_le_uint_at "$prefix" $((entry_offset + 40)) 8)"
+      if ((first_lba <= 0 || last_lba < first_lba)); then
+        uefisign_die "Invalid EFI partition bounds in GPT"
+      fi
+      sectors=$((last_lba - first_lba + 1))
+      printf '%s %s\n' "$first_lba" "$sectors"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+uefisign_find_efi_partition() {
+  local input="$1"
+  local input_type="$2"
+  local prefix="$3"
+  local signature gpt_signature entries_end prefix_size
+
+  uefisign_extract_raw_range_to_file "$input" "$input_type" 0 "$UEFISIGN_PARTITION_PREFIX_BYTES" "$prefix"
+
+  signature="$(uefisign_hex_at "$prefix" 510 2)"
+  if [[ "$signature" != "55aa" ]]; then
+    uefisign_die "Raw image does not have an MBR boot signature"
+  fi
+
+  gpt_signature="$(uefisign_hex_at "$prefix" "$UEFISIGN_SECTOR_SIZE" 8)"
+  if [[ "$gpt_signature" == "4546492050415254" ]]; then
+    entries_end="$(uefisign_gpt_entries_end "$prefix")"
+    prefix_size="$(stat -c%s -- "$prefix")"
+    # Most images fit in the default prefix, but GPT allows a larger partition
+    # entry array. Pull exactly enough bytes if this image needs more.
+    if ((entries_end > prefix_size)); then
+      uefisign_extract_raw_range_to_file "$input" "$input_type" 0 "$entries_end" "$prefix"
+    fi
+    if ! uefisign_parse_gpt_esp "$prefix"; then
+      uefisign_die "Could not determine EFI partition info from GPT"
+    fi
+    return 0
+  fi
+
+  if ! uefisign_parse_mbr_esp "$prefix"; then
+    uefisign_die "Could not determine EFI partition info from MBR"
+  fi
+}
+
+uefisign_write_signed_raw_image() {
+  local input="$1"
+  local input_type="$2"
+  local efi_image="$3"
+  local efi_offset="$4"
+  local efi_size="$5"
+  local output="$6"
+  local output_type="$7"
+  local after_efi output_tmp actual_efi_size output_dir
+
+  actual_efi_size="$(stat -c%s -- "$efi_image")"
+  if ((actual_efi_size != efi_size)); then
+    uefisign_die "EFI image size changed: expected $efi_size bytes, got $actual_efi_size"
+  fi
+
+  output_dir="$(dirname -- "$output")"
+  mkdir -p -- "$output_dir"
+  output_tmp="${output}.tmp.$$"
+  rm -f -- "$output_tmp"
+
+  after_efi=$((efi_offset + efi_size))
+  case "$output_type" in
+  zst)
+    # Recompose the raw image as a stream. This trades extra decompression CPU
+    # for avoiding a full-size temporary disk.raw.
+    {
+      uefisign_stream_raw_range "$input" "$input_type" 0 "$efi_offset"
+      cat -- "$efi_image"
+      uefisign_stream_raw_range "$input" "$input_type" "$after_efi"
+    } | zstd -f -o "$output_tmp"
+    ;;
+  raw)
+    if [[ "$input_type" == "raw" ]]; then
+      # Raw inputs may be sparse. Preserve their holes by copying the original
+      # image sparsely, then patch only the modified ESP into the copy.
+      cp --sparse=always --reflink=auto -- "$input" "$output_tmp"
+      dd if="$efi_image" of="$output_tmp" bs="$UEFISIGN_STREAM_BS" \
+        oflag=seek_bytes seek="$efi_offset" conv=notrunc status=none
+    else
+      # If a future caller asks for raw output from a stream, recreate holes
+      # for all-zero blocks instead of fully allocating the output image.
+      {
+        uefisign_stream_raw_range "$input" "$input_type" 0 "$efi_offset"
+        cat -- "$efi_image"
+        uefisign_stream_raw_range "$input" "$input_type" "$after_efi"
+      } | dd of="$output_tmp" bs="$UEFISIGN_STREAM_BS" conv=sparse status=none
+    fi
+    ;;
+  *)
+    rm -f -- "$output_tmp"
+    uefisign_die "Unsupported output type: $output_type"
+    ;;
+  esac
+
+  mv -f -- "$output_tmp" "$output"
+}

--- a/secboot/uefi-sign-azure.sh
+++ b/secboot/uefi-sign-azure.sh
@@ -19,7 +19,18 @@ err_report() {
 }
 trap 'err_report $LINENO' ERR
 
+if ! declare -F uefisign_find_efi_partition >/dev/null; then
+    SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck disable=SC1091
+    # shellcheck source=uefi-raw-image-lib.sh
+    source "$SCRIPT_DIR/uefi-raw-image-lib.sh"
+fi
+
 # Input and constants
+if [[ $# -eq 2 && -n "${UEFISIGN_AZURE_CERT:-}" ]]; then
+    set -- "$UEFISIGN_AZURE_CERT" "$@"
+fi
+
 if [[ $# -ne 3 ]]; then
     log "[!] Usage: $0 <certificate> <disk-image.zst> <subdir>"
     log "[!] Please make sure AZURE_CLI_ACCESS_TOKEN variable is set before running."
@@ -29,19 +40,16 @@ fi
 
 SUBDIR="$3"
 DISK_IMAGE_ZST="$2"
-DISK_IMAGE="disk.raw"
-DISK_IMAGE_ISO="disk.iso"
-EFI_IMAGE="efi-partition.img"
-SIGNED_EFI="BOOTX64.EFI.signed"
 CERT="$1"
 KEY="vault:ghaf-secureboot-testkv:uefi-signing-key"
 ZSTD_IMAGE="ghaf_0.0.1.raw.zst"
 
-if [ -z "$AZURE_CLI_ACCESS_TOKEN" ]; then
+if [ -z "${AZURE_CLI_ACCESS_TOKEN:-}" ]; then
     log "[DEBUG] querying Azure metadata server for access token..."
-    export AZURE_CLI_ACCESS_TOKEN=$(curl -s \
+    AZURE_CLI_ACCESS_TOKEN=$(curl -s \
         'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://vault.azure.net' \
         -H "Metadata: true" | jq -r .access_token)
+    export AZURE_CLI_ACCESS_TOKEN
 fi
 
 log "[DEBUG] cert: $1"
@@ -66,43 +74,36 @@ case "$DISK_IMAGE_ZST" in
     ;;
 esac
 
+TMPWDIR="$(mktemp -d --suffix .uefisign-azure)"
+EFI_IMAGE="$TMPWDIR/efi-partition.img"
+SIGNED_EFI="$TMPWDIR/BOOTX64.EFI.signed"
+BOOT_EFI="$TMPWDIR/BOOTX64.EFI"
+
+on_exit() {
+    log "[DEBUG] Cleanup (TMPWDIR:$TMPWDIR)"
+    rm -fr "$TMPWDIR"
+}
+trap on_exit EXIT
+
 # Ensure required tools are available
-for cmd in zstd fdisk dd mcopy sbsign; do
+for cmd in zstd dd mcopy sbsign; do
     if ! command -v "$cmd" &>/dev/null; then
         log "[!] Required tool '$cmd' not found in PATH"
         exit 1
     fi
 done
 
-log "[*] Cleaning up any previous artifacts..."
-rm -f "$DISK_IMAGE" "$EFI_IMAGE" "$SIGNED_EFI" BOOTX64.EFI
-
-if [[ "$input_type" == "zst" ]]; then
-    log "[*] Decompressing image: $DISK_IMAGE_ZST -> $DISK_IMAGE"
-    zstd -d "$DISK_IMAGE_ZST" -o "$DISK_IMAGE"
-else
-    cp $DISK_IMAGE_ZST $DISK_IMAGE_ISO
-    DISK_IMAGE=$DISK_IMAGE_ISO
-fi
-log "[*] Disk image: $DISK_IMAGE"
-chmod 666 "$DISK_IMAGE"
-
 log "[*] Locating EFI partition offset and size..."
-read -r EFI_START SECTORS < <(fdisk -l "$DISK_IMAGE" | awk '$0 ~ /EFI / { print $2, $4 }')
-if [[ -z "${EFI_START:-}" || -z "${SECTORS:-}" ]]; then
-    log "[!] Could not determine EFI partition info from image"
-    exit 1
-fi
-
+read -r EFI_START SECTORS < <(uefisign_find_efi_partition "$DISK_IMAGE_ZST" "$input_type" "$TMPWDIR/partition-prefix.img")
 EFI_OFFSET=$((EFI_START * 512))
 EFI_SIZE=$((SECTORS * 512))
 log "[*] EFI offset: $EFI_OFFSET, size: $EFI_SIZE bytes"
 
 log "[*] Extracting EFI partition to $EFI_IMAGE..."
-dd if="$DISK_IMAGE" of="$EFI_IMAGE" bs=512 skip="$EFI_START" count="$SECTORS" status=none
+uefisign_extract_raw_range_to_file "$DISK_IMAGE_ZST" "$input_type" "$EFI_OFFSET" "$EFI_SIZE" "$EFI_IMAGE"
 
 log "[*] Extracting BOOTX64.EFI..."
-if ! mcopy -i "$EFI_IMAGE" ::EFI/BOOT/BOOTX64.EFI BOOTX64.EFI; then
+if ! mcopy -i "$EFI_IMAGE" ::EFI/BOOT/BOOTX64.EFI "$BOOT_EFI"; then
     log "[!] Failed to extract BOOTX64.EFI from EFI image"
     exit 1
 fi
@@ -110,7 +111,7 @@ fi
 log "[*] Signing BOOTX64.EFI..."
 
 log "[DEBUG] Running: sbsign with params --key $KEY --cert $CERT --output $SIGNED_EFI"
-sbsign --engine e_akv --keyform engine --key "$KEY" --cert "$CERT" --output "$SIGNED_EFI" BOOTX64.EFI 2>&1 | tee /tmp/sbsign.log
+sbsign --engine e_akv --keyform engine --key "$KEY" --cert "$CERT" --output "$SIGNED_EFI" "$BOOT_EFI" 2>&1 | tee /tmp/sbsign.log
 ret=$?
 if [[ $ret -ne 0 ]]; then
     log "[!] sbsign failed (exit code $ret)"
@@ -124,22 +125,10 @@ if ! mcopy -o -i "$EFI_IMAGE" "$SIGNED_EFI" ::EFI/BOOT/BOOTX64.EFI; then
     exit 1
 fi
 
-log "[*] Writing updated EFI partition back to disk image..."
-dd if="$EFI_IMAGE" of="$DISK_IMAGE" bs=512 seek="$EFI_START" conv=notrunc status=none
-
-log "[+] Signed image is ready in $DISK_IMAGE"
-
 if [[ "$input_type" == "zst" ]]; then
     SIGNED_ZST="signed_$ZSTD_IMAGE"
-    log "[*] Recompressing signed image to $SIGNED_ZST..."
-    zstd -f "$DISK_IMAGE" -o "$SIGNED_ZST"
-    log "[*] Move signed image to $SUBDIR"
-    mkdir -p $SUBDIR
-    mv $SIGNED_ZST $SUBDIR
-else
-    log "[*] Move signed image to $SUBDIR"
-    mkdir -p $SUBDIR
-    mv $DISK_IMAGE_ISO $SUBDIR
+    log "[*] Streaming signed image to $SUBDIR/$SIGNED_ZST..."
+    uefisign_write_signed_raw_image "$DISK_IMAGE_ZST" "$input_type" "$EFI_IMAGE" "$EFI_OFFSET" "$EFI_SIZE" "$SUBDIR/$SIGNED_ZST" zst
 fi
 
 log "[+] EFI Signing Success!"

--- a/secboot/uefi-sign-raw.sh
+++ b/secboot/uefi-sign-raw.sh
@@ -13,6 +13,13 @@ err_report() {
 }
 trap 'err_report $LINENO' ERR
 
+if ! declare -F uefisign_find_efi_partition >/dev/null; then
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck disable=SC1091
+  # shellcheck source=uefi-raw-image-lib.sh
+  source "$SCRIPT_DIR/uefi-raw-image-lib.sh"
+fi
+
 if [[ $# -ne 4 ]]; then
   log "[!] Usage: $0 <certificate> <private-key> <disk-image.zst> <out-dir>"
   exit 1
@@ -24,7 +31,6 @@ DISK_IMAGE_ZST="$3"
 OUTDIR="$4"
 
 TMPWDIR="$(mktemp -d --suffix .uefisign)"
-DISK_IMAGE="$TMPWDIR/disk.raw"
 EFI_IMAGE="$TMPWDIR/efi-partition.img"
 SIGNED_EFI="$TMPWDIR/BOOTX64.EFI.signed"
 SIGNED_ZST="$OUTDIR/signed_$(basename "$DISK_IMAGE_ZST")"
@@ -50,25 +56,14 @@ case "$DISK_IMAGE_ZST" in
   ;;
 esac
 
-if [[ "$input_type" == "zst" ]]; then
-  log "[*] Decompressing image: $DISK_IMAGE_ZST -> $DISK_IMAGE"
-  zstd -d "$DISK_IMAGE_ZST" -o "$DISK_IMAGE"
-fi
-log "[*] Disk image: $DISK_IMAGE"
-chmod 666 "$DISK_IMAGE" || true
-
 log "[*] Locating EFI partition offset and size..."
-read -r EFI_START SECTORS < <(fdisk -l "$DISK_IMAGE" | awk '$0 ~ /EFI / { print $2, $4 }')
-if [[ -z "${EFI_START:-}" || -z "${SECTORS:-}" ]]; then
-  log "[!] Could not determine EFI partition info from image"
-  exit 1
-fi
+read -r EFI_START SECTORS < <(uefisign_find_efi_partition "$DISK_IMAGE_ZST" "$input_type" "$TMPWDIR/partition-prefix.img")
 EFI_OFFSET=$((EFI_START * 512))
 EFI_SIZE=$((SECTORS * 512))
 log "[*] EFI offset: $EFI_OFFSET, size: $EFI_SIZE bytes"
 
 log "[*] Extracting EFI partition to $EFI_IMAGE..."
-dd if="$DISK_IMAGE" of="$EFI_IMAGE" bs=512 skip="$EFI_START" count="$SECTORS" status=none
+uefisign_extract_raw_range_to_file "$DISK_IMAGE_ZST" "$input_type" "$EFI_OFFSET" "$EFI_SIZE" "$EFI_IMAGE"
 
 fat_path() {
   # Convert backslashes to forward slashes, ensure leading slash
@@ -182,15 +177,8 @@ mcopy -o -i "$EFI_IMAGE" "$TMPWDIR/tmp_entry" "::/loader/entries/$(basename "$en
 log "[*] Updating fallback EFI/BOOT/BOOTX64.EFI ..."
 mcopy -o -i "$EFI_IMAGE" "$SIGNED_EFI" ::/EFI/BOOT/BOOTX64.EFI
 
-log "[*] Writing updated EFI partition back to disk image..."
-dd if="$EFI_IMAGE" of="$DISK_IMAGE" bs=512 seek="$EFI_START" conv=notrunc status=none
-
-log "[+] Signed image updated in $DISK_IMAGE"
-
 mkdir -p "$OUTDIR"
-if [[ "$input_type" == "zst" ]]; then
-  log "[*] Recompressing signed image to $SIGNED_ZST..."
-  zstd -f "$DISK_IMAGE" -o "$SIGNED_ZST"
-fi
+log "[*] Streaming signed image to $SIGNED_ZST..."
+uefisign_write_signed_raw_image "$DISK_IMAGE_ZST" "$input_type" "$EFI_IMAGE" "$EFI_OFFSET" "$EFI_SIZE" "$SIGNED_ZST" zst
 
 log "[+] EFI Signing Success!"

--- a/secboot/uefi-sign-simple.sh
+++ b/secboot/uefi-sign-simple.sh
@@ -4,14 +4,22 @@
 
 set -euo pipefail
 
+if ! declare -F uefisign_find_efi_partition >/dev/null; then
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  # shellcheck disable=SC1091
+  # shellcheck source=uefi-raw-image-lib.sh
+  source "$SCRIPT_DIR/uefi-raw-image-lib.sh"
+fi
+
 CERT="$1"
 PKEY="$2"
-DISK_IMAGE="$3"
+DISK_IMAGE_INPUT="$3"
 OUTDIR="${4%/}"
 
 RECOMPRESS=0
-IMG_NAME="$(basename "$DISK_IMAGE")"
+IMG_NAME="$(basename "$DISK_IMAGE_INPUT")"
 TMPDIR="$(mktemp -d)"
+EFI_IMAGE="$TMPDIR/efi-partition.img"
 
 cleanup() {
   rm -fr "$TMPDIR"
@@ -25,34 +33,21 @@ if [[ "$CERT" == pkcs11:* ]]; then
   CERT_PROV="provider:pkcs11"
 fi
 
-decompress_image() {
+detect_image() {
   case "$1" in
   *.zst)
     IMG_NAME=${IMG_NAME%.*}
     RECOMPRESS=1
-    echo "Decompressing zst archive"
-    zstd -d "$1" -o "$TMPDIR/$IMG_NAME"
+    input_type="zst"
     ;;
   *.img | *.raw)
-    cp "$1" "$TMPDIR/$IMG_NAME"
+    input_type="raw"
     ;;
   *)
     echo "Unknown input file format!" >&2
     exit 1
     ;;
   esac
-  DISK_IMAGE="$TMPDIR/$IMG_NAME"
-}
-
-get_esp_offset() {
-  ESP_GUID="C12A7328-F81F-11D2-BA4B-00A0C93EC93B" # well known
-  # aarch64 orin images have type="b" on the esp
-  ESP_START=$(sfdisk --json "$DISK_IMAGE" | jq -r ".partitiontable.partitions[] | select(.type==\"b\" or .type==\"$ESP_GUID\") | .start")
-  if [[ -z "$ESP_START" ]]; then
-    echo "Unable to automatically detect ESP partition offset!" >&2
-    exit 1
-  fi
-  echo $(("$ESP_START" * 512))
 }
 
 sign_file() {
@@ -65,22 +60,27 @@ sign_file() {
     --output "$1" "$1"
 }
 
-decompress_image "$DISK_IMAGE"
-chmod +w "$DISK_IMAGE"
-ESP_OFFSET="$(get_esp_offset)"
+detect_image "$DISK_IMAGE_INPUT"
+
+read -r ESP_START SECTORS < <(uefisign_find_efi_partition "$DISK_IMAGE_INPUT" "$input_type" "$TMPDIR/partition-prefix.img")
+ESP_OFFSET=$((ESP_START * 512))
+ESP_SIZE=$((SECTORS * 512))
+echo "EFI offset: $ESP_OFFSET, size: $ESP_SIZE bytes"
+
+uefisign_extract_raw_range_to_file "$DISK_IMAGE_INPUT" "$input_type" "$ESP_OFFSET" "$ESP_SIZE" "$EFI_IMAGE"
 
 # copy the bootloader
-BOOTLOADER="$(mdir -i "$DISK_IMAGE@@$ESP_OFFSET" ::/EFI/BOOT/ | awk '/BOOTAA64|BOOTX64/ {print $1; exit}').EFI"
-mcopy -i "$DISK_IMAGE@@$ESP_OFFSET" "::/EFI/BOOT/$BOOTLOADER" "$TMPDIR/"
+BOOTLOADER="$(mdir -i "$EFI_IMAGE" ::/EFI/BOOT/ | awk '/BOOTAA64|BOOTX64/ {print $1; exit}').EFI"
+mcopy -i "$EFI_IMAGE" "::/EFI/BOOT/$BOOTLOADER" "$TMPDIR/"
 
 # find and copy the kernel image
-mcopy -i "$DISK_IMAGE@@$ESP_OFFSET" "::/loader/entries/*.conf" "$TMPDIR/loader.conf"
+mcopy -i "$EFI_IMAGE" "::/loader/entries/*.conf" "$TMPDIR/loader.conf"
 KERNEL_PATH="$(awk '/^linux[[:space:]]/{print $2; exit}' "$TMPDIR/loader.conf")"
 if [[ -z "$KERNEL_PATH" ]]; then
   echo "Unable to find kernel path from loader conf!" >&2
   exit 1
 fi
-mcopy -i "$DISK_IMAGE@@$ESP_OFFSET" "::$KERNEL_PATH" "$TMPDIR/"
+mcopy -i "$EFI_IMAGE" "::$KERNEL_PATH" "$TMPDIR/"
 KERNEL_NAME="$(basename "$KERNEL_PATH")"
 
 # sign both
@@ -88,16 +88,15 @@ sign_file "$TMPDIR/$KERNEL_NAME"
 sign_file "$TMPDIR/$BOOTLOADER"
 
 # copy signed files into the image and overwrite the existing files
-mcopy -o -i "$DISK_IMAGE@@$ESP_OFFSET" "$TMPDIR/$KERNEL_NAME" "::$(dirname "$KERNEL_PATH")/"
-mcopy -o -i "$DISK_IMAGE@@$ESP_OFFSET" "$TMPDIR/$BOOTLOADER" "::/EFI/BOOT/"
+mcopy -o -i "$EFI_IMAGE" "$TMPDIR/$KERNEL_NAME" "::$(dirname "$KERNEL_PATH")/"
+mcopy -o -i "$EFI_IMAGE" "$TMPDIR/$BOOTLOADER" "::/EFI/BOOT/"
 
 # move signed file to outdir, recompressing if it was originally compressed
 if [[ "$RECOMPRESS" == 1 ]]; then
-  echo "Recompressing signed image to zst archive"
-  zstd -f "$DISK_IMAGE" -o "$DISK_IMAGE.zst"
-  mv "$DISK_IMAGE.zst" "$OUTDIR/signed_$IMG_NAME.zst"
+  echo "Streaming signed image to zst archive"
+  uefisign_write_signed_raw_image "$DISK_IMAGE_INPUT" "$input_type" "$EFI_IMAGE" "$ESP_OFFSET" "$ESP_SIZE" "$OUTDIR/signed_$IMG_NAME.zst" zst
   echo "Wrote signed image to $OUTDIR/signed_$IMG_NAME.zst"
 else
-  mv "$DISK_IMAGE" "$OUTDIR/signed_$IMG_NAME"
+  uefisign_write_signed_raw_image "$DISK_IMAGE_INPUT" "$input_type" "$EFI_IMAGE" "$ESP_OFFSET" "$ESP_SIZE" "$OUTDIR/signed_$IMG_NAME" raw
   echo "Wrote signed image to $OUTDIR/signed_$IMG_NAME"
 fi


### PR DESCRIPTION
Stream UEFI raw-image signing instead of fully decompressing images to disk.

This adds shared raw-image helpers for ESP detection, byte-range extraction, and streamed image recomposition, then updates the raw/simple/Azure/deployed signing paths to use them. This reduces temporary disk usage for large images.

#### High-level flow

This change avoids fully decompressing large `.raw.zst` disk images just to update the EFI partition.

Before:
```text
.raw.zst -> decompress full disk.raw -> patch EFI partition -> recompress full disk.raw
```
After:
```text
read partition metadata
find EFI partition offset/size
extract only the EFI partition
modify/sign the EFI partition
stream final output:
  original bytes before EFI
  modified EFI partition
  original bytes after EFI
compress the stream back to .raw.zst
```

The main idea is that the full raw image is treated as a byte stream, and only the EFI partition is materialized on disk.

`uefi-raw-image-lib.sh` contains the shared helpers for reading raw/`.zst` byte ranges, parsing MBR/GPT partition metadata, extracting the EFI partition, and recomposing the final image
stream. The signing scripts still perform the same signing work; they just use the streaming helper instead of creating a full temporary raw disk image.

#### How this was tested?
- Built UEFI-signed images in ci-dbg using the ci-yubi tooling from this PR:
  - https://ci-dbg.vedenemo.dev/job/ghaf-release-candidate/24/
- Manually triggered `ghaf-hw-test` in ci-prod with `SECUREBOOT` enabled:
  -  https://ci-prod.vedenemo.dev/job/ghaf-hw-test/24561/ (original flash)
  - https://ci-prod.vedenemo.dev/job/ghaf-hw-test/24562/ (second run to verify flash/boot when the initial image was already signed with this PR)
- Both runs passed ´_relayboot_´ test